### PR TITLE
Generic network boot ipxe-files

### DIFF
--- a/roles/lbs_network_boot/tasks/ipxe-config-domain.yml
+++ b/roles/lbs_network_boot/tasks/ipxe-config-domain.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Copy domain-specific ipxe config for {{ item }}
+  ansible.builtin.template:
+    src: boot.ipxe.j2
+    dest: "{{ network_boot_nginx_ipxe_files_dir }}/{{ item }}.ipxe"
+    mode: '0644'

--- a/roles/lbs_network_boot/tasks/ipxe-config-ipv4.yml
+++ b/roles/lbs_network_boot/tasks/ipxe-config-ipv4.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: Copy domain-specific ipxe config for {{ item }}
-  ansible.builtin.template:
-    src: boot.ipxe.j2
-    dest: "{{ network_boot_nginx_ipxe_files_dir }}/{{ item }}.ipxe"
-    mode: '0644'
-
 - name: Copy IPv4-specific ipxe config for {{ item }}
   ansible.builtin.template:
     src: boot.ipxe.j2

--- a/roles/lbs_network_boot/tasks/main.yml
+++ b/roles/lbs_network_boot/tasks/main.yml
@@ -117,3 +117,8 @@
 - name: Copy IPv4-specific ipxe config files for nodes
   ansible.builtin.include_tasks: "ipxe-config-ipv4.yml"
   loop: "{{ groups.nodes }}"
+
+- name: Copy generic ipxe config files for worker nodes
+  ansible.builtin.include_tasks: "ipxe-config-domain.yml"
+  loop:
+    - worker

--- a/roles/lbs_network_boot/tasks/main.yml
+++ b/roles/lbs_network_boot/tasks/main.yml
@@ -110,6 +110,10 @@
     dest: "{{ network_boot_nginx_ipxe_files_dir }}/autoexec.ipxe"
     mode: '0644'
 
-- name: Copy host specific ipxe config files
-  ansible.builtin.include_tasks: "ipxe-config.yml"
+- name: Copy domain-specific ipxe config files for nodes
+  ansible.builtin.include_tasks: "ipxe-config-domain.yml"
+  loop: "{{ groups.nodes }}"
+
+- name: Copy IPv4-specific ipxe config files for nodes
+  ansible.builtin.include_tasks: "ipxe-config-ipv4.yml"
   loop: "{{ groups.nodes }}"


### PR DESCRIPTION
Useful when adding a worker at a later date. 